### PR TITLE
FASP-9 Update Dog-Finder Api Calls to only search for puppies.

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -28,7 +28,10 @@ class FormController extends Controller
         $this->validateLandingForm($request);
         $selection =  $this->storeSelection($request);
         $this->storeUser($request,$selection->id);
-        return view('welcome');
+
+        $allBreedNames = Breed::all();
+        return view('welcome')->with('allBreedNames', $allBreedNames);
+
     }
 
     public function validateLandingForm(Request $request)

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -8,9 +8,6 @@ use App\Services\NotificationService;
 use Illuminate\Http\Request;
 use App\Selection;
 use App\User;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Validation\Rule;
-use Psy\Exception\ErrorException;
 
 class FormController extends Controller
 {
@@ -39,18 +36,13 @@ class FormController extends Controller
         $this->validate($request, [
             'email'     => 'required|email',
             'maxMiles'  => 'required|integer|between:1,200',
-            'zip'       => 'required|regex:/\b\d{5}\b/',
-            'breedName' => [
-                'required',
-                Rule::in(json_decode(Storage::disk('local')->get('/data/breeds.json')))
-            ]
+            'zip'       => 'required|regex:/\b\d{5}\b/'
         ]);
     }
 
     public function storeSelection(Request $request){
-        $breedArray = $this->externalPetApiService->getExternalDataForBreed($request->zip, $request->breedName);
+        $breedArray = $this->externalPetApiService->getExternalDataForDogs($request->zip);
         return Selection::create([
-            'breed_id' => $this->dogDataService->getBreedId($request->breedName),
             'zip' => $request->zip,
             'highest_breed_id' => $this->dogDataService->getLargestBreedId($breedArray),
             'max_miles' => $request->maxMiles,

--- a/app/Selection.php
+++ b/app/Selection.php
@@ -9,14 +9,10 @@ class Selection extends Model
     public $timestamps = true;
     public $primaryKey = 'id';
 
-    protected $fillable = ['id','breed_id', 'zip','highest_breed_id', 'max_miles', 'match'];
+    protected $fillable = ['id','zip','highest_breed_id', 'max_miles', 'match'];
 
     public function users(){
         return $this->hasOne('App\User', 'selection_id','id');
-    }
-
-    public function breed(){
-        return $this->hasOne('App\Breed', 'id', 'breed_id');
     }
 
 }

--- a/app/Services/DogDataService.php
+++ b/app/Services/DogDataService.php
@@ -18,8 +18,7 @@ class DogDataService
 
     public function getUpdatedBreedArray($email){
         $selection = User::whereEmail($email)->with('selection')->firstOrFail()->selection;
-        $breedName = Breed::find($selection->breed_id)->breed;
-        $breeds = $this->externalPetApiService->getExternalDataForBreed($selection->zip, $breedName);
+        $breeds = $this->externalPetApiService->getExternalDataForDogs($selection->zip);
         $latestMaxId = $this->getLargestBreedId($breeds);
 
         $this->updateHighestBreedId($selection->id, $latestMaxId);

--- a/app/Services/ExternalPetApiService.php
+++ b/app/Services/ExternalPetApiService.php
@@ -10,19 +10,19 @@ class ExternalPetApiService
     private $countOfDogsRequested = 75;
 
 
-    public function getExternalDataForBreed($location, $breed)
+    public function getExternalDataForBreed($location)
     {
-        $data = $this->getRawDogApiData($location, $breed);
+        $data = $this->getRawDogApiData($location);
         $data = $this->validateDogData($data);
         return $data;
     }
 
-    public function getRawDogApiData($location, $breed){
+    public function getRawDogApiData($location){
         $client = new \GuzzleHttp\Client();
         $response = $client->request('GET', 'api.petfinder.com/pet.find?' .
             'key=' . env('API_KEY') . '&' .
             'location=' . $location . '&' .
-            'breed=' . $breed . '&' .
+            'age=Baby&' .
             'count='.$this->countOfDogsRequested. '&' .
             'format=json' . '&' .
             'offset=0'

--- a/app/Services/ExternalPetApiService.php
+++ b/app/Services/ExternalPetApiService.php
@@ -10,7 +10,7 @@ class ExternalPetApiService
     private $countOfDogsRequested = 75;
 
 
-    public function getExternalDataForBreed($location)
+    public function getExternalDataForDogs($location)
     {
         $data = $this->getRawDogApiData($location);
         $data = $this->validateDogData($data);

--- a/database/factories/SelectionFactory.php
+++ b/database/factories/SelectionFactory.php
@@ -3,7 +3,6 @@
 use Faker\Generator as Faker;
 $factory->define(\App\Selection::class, function (Faker $faker) {
     return [
-        'breed_id'         => $faker->numberBetween(1,249),
         'zip'              => $faker->numberBetween(90001,96162),
         'highest_breed_id' => $faker->numberBetween(41509748, 41540000),
         'max_miles'        => $faker->randomElement(['50', '75', '100']),

--- a/database/migrations/2018_02_09_082439_create_selections_table.php
+++ b/database/migrations/2018_02_09_082439_create_selections_table.php
@@ -15,7 +15,6 @@ class CreateSelectionsTable extends Migration
     {
         Schema::create('selections', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('breed_id');
             $table->string('zip');
             $table->integer('highest_breed_id');
             $table->integer('max_miles');

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,4 +32,4 @@ Route::get('/user/breed/{email}', 'UserController@getUserBreed');
 Route::get('/user/miles/{email}', 'UserController@getUserMiles');
 
 //Selection
-Route::post('/selection/{breedName}/{zip}/{maxMiles}', 'FormController@storeSelection');
+Route::post('/selection/{zip}/{maxMiles}', 'FormController@storeSelection');

--- a/tests/Api/ExternalPetApiServiceTest.php
+++ b/tests/Api/ExternalPetApiServiceTest.php
@@ -34,14 +34,13 @@ class ExternalPetApiServiceTest extends TestCase
 
     //API CALL
     public function test_getExternalDataForBreed_ReturnsDataWhenSuccessful(){
-        $response = $this->service->getExternalDataForBreed($this->validZip,$this->validBreed);
+        $response = $this->service->getExternalDataForBreed($this->validZip);
         $this->assertEquals($this->service->getCount(),count($response));
-
     }
     //API CALL
     public function test_getExternalDataForBreed_ReturnsExceptionWhenApiReturnsNoData(){
         $this->expectException($this->indexException);
-        $this->service->getExternalDataForBreed($this->invalidZip,$this->invalidBreed);
+        $this->service->getExternalDataForBreed($this->invalidZip);
     }
     //API CALL
     public function test_getRawDogApiData_ReturnsSucess()

--- a/tests/Api/ExternalPetApiServiceTest.php
+++ b/tests/Api/ExternalPetApiServiceTest.php
@@ -15,8 +15,6 @@ class ExternalPetApiServiceTest extends TestCase
     private $validData, $invalidData;
     private $validZip = 91324;
     private $invalidZip = 11111;
-    private $validBreed = 'Akita';
-    private $invalidBreed = 'Huzzky';
 
     private $indexException;
     private $invalidPetIdException;
@@ -33,19 +31,19 @@ class ExternalPetApiServiceTest extends TestCase
     }
 
     //API CALL
-    public function test_getExternalDataForBreed_ReturnsDataWhenSuccessful(){
-        $response = $this->service->getExternalDataForBreed($this->validZip);
+    public function test_getExternalDataForDogs_ReturnsDataWhenSuccessful(){
+        $response = $this->service->getExternalDataForDogs($this->validZip);
         $this->assertEquals($this->service->getCount(),count($response));
     }
     //API CALL
-    public function test_getExternalDataForBreed_ReturnsExceptionWhenApiReturnsNoData(){
+    public function test_getExternalDataForDogs_ReturnsExceptionWhenApiReturnsNoData(){
         $this->expectException($this->indexException);
-        $this->service->getExternalDataForBreed($this->invalidZip);
+        $this->service->getExternalDataForDogs($this->invalidZip);
     }
     //API CALL
     public function test_getRawDogApiData_ReturnsSucess()
     {
-        $response = $this->service->getRawDogApiData($this->validZip, $this->validBreed);
+        $response = $this->service->getRawDogApiData($this->validZip);
         $status_code = $response['petfinder']['header']['status']['code']['$t'];
         $arrayOfPets = $response['petfinder']['pets']['pet'];
         $this->assertEquals(100,$status_code);
@@ -175,11 +173,11 @@ class ExternalPetApiServiceTest extends TestCase
         $this->assertArrayHasKey('media',$dogData);
     }
     public function getValidData(){
-        return $this->service->getRawDogApiData($this->validZip,$this->validBreed);
+        return $this->service->getRawDogApiData($this->validZip);
     }
 
     public function getInvalidData(){
-        return $this->service->getRawDogApiData($this->invalidZip, $this->invalidBreed);
+        return $this->service->getRawDogApiData($this->invalidZip);
     }
 
     public function mock_pet_api_data_for_single_dog(){

--- a/tests/Unit/FormControllerTest.php
+++ b/tests/Unit/FormControllerTest.php
@@ -60,12 +60,6 @@ class FormControllerTest extends TestCase
         $this->sendForm(['zip' => ''])->assertSessionHasErrors('zip');
     }
 
-    public function test_StoreUsersSelection_RequiresValidBreedName()
-    {
-        $this->sendForm(['breedName' => 'notarealbreed'])->assertSessionHasErrors('breedName');
-        $this->sendForm(['breedName' => ''])->assertSessionHasErrors('breedName');
-    }
-
     public function test_StoreUsersSelection_StoresUser()
     {
         $this->sendForm();
@@ -96,7 +90,6 @@ class FormControllerTest extends TestCase
             'email' => 'johndoe@gmail.com',
             'maxMiles' => 75,
             'zip' => 95492,
-            'breedName' => 'Akita'
         ], $overrides);
     }
 }

--- a/tests/Unit/FormControllerTest.php
+++ b/tests/Unit/FormControllerTest.php
@@ -18,8 +18,6 @@ class FormControllerTest extends TestCase
     private $url = "/";
     private $numRows = 4;
     private $form;
-    private $validBreedId = 5;
-    private $validBreed = 'Akita';
     private $validZip = '95402';
     private $validMiles = 50;
     //Services

--- a/tests/Unit/FormControllerTest.php
+++ b/tests/Unit/FormControllerTest.php
@@ -67,10 +67,9 @@ class FormControllerTest extends TestCase
     }
 
     public function test_storeSelection_stores_single_row_in_database(){
-        $this->post('/selection/'.$this->validBreed.'/'.$this->validZip.'/'.$this->validMiles);
+        $this->post('/selection/'.$this->validZip.'/'.$this->validMiles);
         $this->assertCount($this->numRows + 1,Selection::all());
         $this->assertDatabaseHas('selections', [
-            'breed_id' => $this->validBreedId,
             'zip'      => $this->validZip,
             'max_miles' => $this->validMiles,
             'match'    => 0

--- a/tests/Unit/UserControllerTest.php
+++ b/tests/Unit/UserControllerTest.php
@@ -28,7 +28,7 @@ class UserControllerTest extends TestCase
     public function setRandomUser()
     {
         $this->user = User::where('id', random_int(1,User::count()))
-                            ->with('selection.breed')
+                            ->with('selection')
                             ->first();
     }
 
@@ -41,18 +41,6 @@ class UserControllerTest extends TestCase
         ]);
         $response->assertJson(['zip' => $this->user->selection->zip]);
 
-    }
-
-    public function test_getUserBreedName()
-    {
-        $response = $this->get('user/breed/'.$this->user->email);
-        $response->assertStatus(200);
-        $response->assertJsonStructure([
-            'name',
-        ]);
-        $response->assertJson([
-           'name' => $this->user->selection->breed->breed,
-        ]);
     }
 
     public function test_getUserMiles()


### PR DESCRIPTION
## Whats this PR do?
- Removes breed parameter from api call in ExternalDogApiService@getRawDogApiData
- Removes breed parameter from related functions
- Adjusts test functions to not expect a breed