### PR TITLE
FASP-18 Add functionality to remove a user's found dogs after a time interval is exceeded

### DIFF
--- a/app/Console/Commands/DeleteExpiredFoundDogs.php
+++ b/app/Console/Commands/DeleteExpiredFoundDogs.php
@@ -6,7 +6,7 @@ use App\Found_Dog;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 
-class deleteExpiredFoundDogs extends Command
+class DeleteExpiredFoundDogs extends Command
 {
     /**
      * The name and signature of the console command.
@@ -39,7 +39,7 @@ class deleteExpiredFoundDogs extends Command
      */
     public function handle()
     {
-        Found_Dog::where('created_at', '<',Carbon::now())->each(function($item){
+        Found_Dog::where('created_at', '<=',Carbon::now()->subDays(14))->each(function($item){
            $item->delete();
         });
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends ConsoleKernel
          $schedule->command('Notify:Reset')
                   ->daily()
                   ->appendOutputTo(storage_path('output.txt'));*/
+         $schedule->command('truncate:dogs')->daily();
     }
 
     /**


### PR DESCRIPTION
## Whats this PR do?
- Adds an artisan command `truncate:dogs`
- Added Laravel Scheduler to run `truncate:dogs` daily

## Steps to Review
- `php artisan schedule:run`
- Add rows to found_dogs table with timestamps older than two weeks
- Verify rows are deleted