### PR TITLE
FASP-31 Removed Breed Form

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -8,6 +8,7 @@ use App\Services\NotificationService;
 use Illuminate\Http\Request;
 use App\Selection;
 use App\User;
+use App\Breed;
 
 class FormController extends Controller
 {

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -116,14 +116,6 @@
                     <br><br>
                     <div class="row padding-bottom-sm">
                         <div class="col-sm-4">
-                            <select name="breedName">
-                                <option value="" disabled selected>Breed...</option>
-                                @foreach($allBreedNames as $name)
-                                <option value="{{$name->breed}}">{{$name->breed}}</option>
-                                @endforeach
-                            </select>  
-                        </div>
-                        <div class="col-sm-4">
                             <input placeholder="Zip Code..." type="number" id="zip" name="zip">
                         </div>
                         <div class="col-sm-4">
@@ -135,11 +127,9 @@
                                 <option value=150>150 Miles</option>
                             </select>  
                         </div> 
-                    </div>
-                    <div class="row padding-bottom-sm">
-                       <div class="col-xs-12">
+                        <div class="col-sm-4">
                             <input placeholder="Email Address..." type="email" name="email">
-                        </div> 
+                        </div>
                     </div>
                     <br>
                    <div class="row">

--- a/tests/Api/DogDataServiceTest.php
+++ b/tests/Api/DogDataServiceTest.php
@@ -31,8 +31,8 @@ class DogDataServiceTest extends TestCase
     {
         $user = factory(User::class)->create();
         Selection::find($user->id)->update([
-            'zip'              => 95492,
-            'highest_breed_id' => 42380000,
+            'zip'              => 91324,
+            'highest_breed_id' => 42390000,
             'max_miles'        => 75
         ]);
         $dogData = $this->dogDataService->getUpdatedBreedArray($user->email);

--- a/tests/Unit/UserControllerTest.php
+++ b/tests/Unit/UserControllerTest.php
@@ -57,13 +57,12 @@ class UserControllerTest extends TestCase
 
     public function test_destroyUser_removes_user_row_with_selection_row_and_found_dogs_row()
     {
-        $validEmail = env('APP_EMAIL');
-        factory(User::class)->create(['email' => $validEmail]);
-        factory(Found_Dog::class)->create(['email' => $validEmail]);
+        $user = factory(User::class)->create();
+        factory(Found_Dog::class)->create(['email' => $user->email]);
         $userCount = User::all()->count();
         $selectionCount = Selection::all()->count();
         $foundDogCount = Found_Dog::all()->count();
-        $this->delete("/user/$validEmail");
+        $this->delete("/user/$user->email");
         $this->assertEquals($userCount - 1,User::all()->count());
         $this->assertEquals($selectionCount - 1,Selection::all()->count());
         $this->assertEquals($foundDogCount - 1,Found_Dog::all()->count());


### PR DESCRIPTION
# What Does this PR Do?
This PR removed the breed form in the bottom form of the webpage

## Steps to Review
1. Switch to master
2. Git pull
3. Git checkout FASP-31
4. Look at the form at the bottom of the home webpage to see that the breed form is no longer there and the forms have been reformatted in response.