### PR TITLE
FASP-24 Do not allow duplicate form submissions on welcome.blade

### DIFF
--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -26,9 +26,7 @@ class FormController extends Controller
         $this->validateLandingForm($request);
         $selection =  $this->storeSelection($request);
         $this->storeUser($request,$selection->id);
-      
-        $allBreedNames = Breed::all();
-        return view('welcome')->with('allBreedNames', $allBreedNames);
+        return back();
     }
 
     public function validateLandingForm(Request $request)
@@ -37,7 +35,7 @@ class FormController extends Controller
         if(!is_null($request->akbar)){
             redirect('/');
         }
-        $this->validate($request, [
+        $request->validate([
             'email'     => 'required|email|unique:users',
             'maxMiles'  => 'required|integer|between:1,200',
             'zip'       => 'required|regex:/\b\d{5}\b/'

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\DogDataService;
 use App\Services\ExternalPetApiService;
 use App\Services\NotificationService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use App\Selection;
 use App\User;
@@ -55,12 +56,17 @@ class FormController extends Controller
     }
 
     public function storeUser($request,$selectionId){
-        return User::create([
-            'rank' => 0,
-            'name' => 'user',
-            'email' => $request->email,
-            'selection_id' => $selectionId,
-        ]);
+        try{
+            User::whereEmail($request->email)->firstOrFail();
+            return User::create([
+                'rank' => 0,
+                'name' => 'user',
+                'email' => $request->email,
+                'selection_id' => $selectionId,
+            ]);
+        }catch(ModelNotFoundException $error){
+            redirect('')->withErrors('This Email Already Exists');
+        }
     }
 
     public function testFunction(){

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Services\DogDataService;
 use App\Services\ExternalPetApiService;
 use App\Services\NotificationService;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use App\Selection;
 use App\User;
@@ -39,7 +38,7 @@ class FormController extends Controller
             redirect('/');
         }
         $this->validate($request, [
-            'email'     => 'required|email',
+            'email'     => 'required|email|unique:users',
             'maxMiles'  => 'required|integer|between:1,200',
             'zip'       => 'required|regex:/\b\d{5}\b/'
         ]);
@@ -56,17 +55,12 @@ class FormController extends Controller
     }
 
     public function storeUser($request,$selectionId){
-        try{
-            User::whereEmail($request->email)->firstOrFail();
-            return User::create([
-                'rank' => 0,
-                'name' => 'user',
-                'email' => $request->email,
-                'selection_id' => $selectionId,
-            ]);
-        }catch(ModelNotFoundException $error){
-            redirect('')->withErrors('This Email Already Exists');
-        }
+        return User::create([
+            'rank' => 0,
+            'name' => 'user',
+            'email' => $request->email,
+            'selection_id' => $selectionId,
+        ]);
     }
 
     public function testFunction(){

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -33,6 +33,10 @@ class FormController extends Controller
 
     public function validateLandingForm(Request $request)
     {
+        //Send the Bot to the home page with no errors, bot protection
+        if(!is_null($request->akbar)){
+            redirect('/');
+        }
         $this->validate($request, [
             'email'     => 'required|email',
             'maxMiles'  => 'required|integer|between:1,200',

--- a/resources/views/partials/master.blade.php
+++ b/resources/views/partials/master.blade.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content='{{ csrf_field() }}'>
     <title>Dog Finder</title>
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
      <title>Find a dog to adopt near you</title>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -110,7 +110,7 @@
     @endif
     <div class="container-fluid search" id="search">
         <div class="row">
-                <form id="regForm" action="{{url('/submit-form')}}" method="POST">
+                <form id="regForm" action="{{url('/create')}}" method="post">
                     {{ csrf_field() }}
                     <h1 class="text-center h1">Find Your New Best Friend</h1>
                     <br><br>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -114,6 +114,10 @@
                     {{ csrf_field() }}
                     <h1 class="text-center h1">Find Your New Best Friend</h1>
                     <br><br>
+                    <div class="special-field" style="display:none">
+                        <label for="akbar">Akbar</label>
+                        <input type="text" name="akbar" id="akbar" value="">
+                    </div>
                     <div class="row padding-bottom-sm">
                         <div class="col-sm-4">
                             <input placeholder="Zip Code..." type="number" id="zip" name="zip">

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,15 +10,9 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-//Services
-use App\Services\ExternalZipApiService;
-use App\Services\ExternalPetApiService;
-
-use App\Services\NotificationService;
-use App\Services\DogDataService;
 
 Route::get('/', 'BreedController@getHomeView');
-Route::post('/submit-form', 'FormController@storeUserSelection');
+Route::post('/create', 'FormController@storeUserSelection');
 Route::view('/results', 'results');
 
 Route::get('/results/{email}', 'BreedController@showCollectedArrayOfDogsView');

--- a/tests/Unit/FormControllerTest.php
+++ b/tests/Unit/FormControllerTest.php
@@ -15,7 +15,7 @@ class FormControllerTest extends TestCase
 {
     use RefreshDatabase;
     //Data
-    private $url = "/submit-form";
+    private $url = "/create";
     private $numRows = 4;
     private $form;
     private $validZip = '95402';


### PR DESCRIPTION
## Whats this PR do?
- Adds validation to halt submission of landing form for existing emails.
- Supplies a useful error message upon duplicate entry.

## Steps to Review
1. Navigate to Landing Page
2. Submit a form consisting of valid input fields
3. Submit a 2nd form consisting of valid input fields while using same email as step 2
4. Verify the landing page is returned with a useful error message describing that 'this email exists'