### PR TITLE
FASP-23 Zip Code Form Validation popup

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,7 +6,7 @@
 <!-- alert for wrong zip code input -->
 <div class="alert alert-warning alert-dismissible collapse" role="alert" id="zip-alert">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-  <strong><p>We're sorry, the zip code you entered was not recognized as a valid zip code.</p></strong><p>Please enter a valid zip code and resubmit the form <a href="#search">below.</a> Thank you. </p>
+  <strong><p>We're sorry, the zip code you entered was not recognized as a valid zip code.</p></strong><p>Please make the corrections and resubmit the form <a href="#search">below.</a> Thank you. </p>
 </div>
 <!-- end alert -->
     <div class="col-xs-12 col-md-7 col-lg-6 text-center">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,7 +6,10 @@
 <!-- alert for wrong zip code input -->
 <div class="alert alert-warning alert-dismissible collapse" role="alert" id="zip-alert">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-  <strong><p>We're sorry, the zip code you entered was not recognized as a valid zip code.</p></strong><p>Please make the corrections and resubmit the form <a href="#search">below.</a> Thank you. </p>
+  @foreach ($errors->all() as $error)
+  <strong><p>{{$error}} </p></strong>
+    @endforeach
+  <p>Please make the corrections and resubmit the form <a href="#search">below.</a> Thank you. </p>
 </div>
 <!-- end alert -->
     <div class="col-xs-12 col-md-7 col-lg-6 text-center">
@@ -130,7 +133,7 @@
                     </div>
                     <div class="row padding-bottom-sm">
                         <div class="col-sm-4">
-                            <input placeholder="Zip Code..." type="number" id="zip" name="zip">
+                            <input placeholder="Zip Code..." type="number" id="zip" name="zip" required>
                         </div>
                         <div class="col-sm-4">
                             <select name="maxMiles" id="maxMiles" required>
@@ -142,7 +145,7 @@
                             </select>  
                         </div> 
                         <div class="col-sm-4">
-                            <input placeholder="Email Address..." type="email" name="email">
+                            <input placeholder="Email Address..." type="email" name="email" required>
                         </div>
                     </div>
                     <br>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,9 +2,16 @@
 
 @section('content')
 <header class="bg-header">
+
+<!-- alert for wrong zip code input -->
+<div class="alert alert-warning alert-dismissible collapse" role="alert" id="zip-alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  <strong><p>We're sorry, the zip code you entered was not recognized as a valid zip code.</p></strong><p>Please enter a valid zip code and resubmit the form <a href="#search">below.</a> Thank you. </p>
+</div>
+<!-- end alert -->
     <div class="col-xs-12 col-md-7 col-lg-6 text-center">
        <h1 class= "h1">Get Alerts the Day <br>a <span style="color: #ff7615;">Puppy You Love</span> <br>is Dropped Off <br>at a Local Shelter 
-    </h1>
+        </h1>
     </div>
 </header>
 <!-- 3 steps -->
@@ -102,13 +109,15 @@
 
 <section>
 
-    @if($errors->any())
-        <ul id="errors">
-            @foreach ($errors->all() as $error)
-                <li>{{$error}}</li>
-            @endforeach
-        </ul>
-    @endif
+<!-- BELOW CODE FOR IF ZIPCODE ERROR THEN SHOW ALERT -->
+@if($errors->any())
+    <script>
+        $(function() {
+            $('#zip-alert').show();
+        });
+    </script>
+@endif
+
     <div class="container-fluid search" id="search">
         <div class="row">
                 <form id="regForm" action="{{url('/create')}}" method="post">
@@ -146,7 +155,7 @@
         </div>
     </div>
 </section>
-
+<!-- success modal popup when form submitted -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel"  aria-hidden=true>
   <div class="modal-dialog" role="document">
     <div class="modal-content">


### PR DESCRIPTION
## Whats This PR Do?
- When a user enters an invalid zip code in the form, an error alert popups with a message asking them to resubmit the form with a valid zip code.

## Steps to Review
- Fill out the form with an invalid zip code and hit submit
- You should see the alert popup at the top of the page. 

### Possible Correction for Cleaner Code:
- the code for the alert popup in the HTML is:
@if($errors->any())
    <script>
        $(function() {
            $('#zip-alert').show();
        });
    </script>
@endif

This is older code that is actually is checking for all errors in the form, not zip code errors specifically, but there are no other possible errors that can come up in the from other than zip code. Do we want to change this code to keep it clean as possible and conventional to be specific to zip code errors?