### PR TITLE
FASP-11 Changed Laravel Mail to use Mailgun Api Service

### DIFF
--- a/app/Notifications/PetArrived.php
+++ b/app/Notifications/PetArrived.php
@@ -45,10 +45,11 @@ class PetArrived extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
+                    ->subject('We Found Puppies Near You')
                     ->greeting('Good News! ')
                     ->line("A puppy has been dropped off within $this->distance miles of a shelter near zip code $this->zip.  Check it out below!")
                     ->action('Show Me', url("/results/$this->email"))
-                    ->line('Thank you for using Findashelterpuppy.com! We hope you find your new best friend.');
+                    ->line('Thank you for using our service! We hope you find your new best friend.');
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Pet Notifier'),
+    'name' => env('APP_NAME', 'FindAShelterPuppy'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mail.php
+++ b/config/mail.php
@@ -16,7 +16,7 @@ return [
     |
     */
 
-    'driver' => env('MAIL_DRIVER', 'smtp'),
+    'driver' => env('MAIL_DRIVER'),
 
     /*
     |--------------------------------------------------------------------------
@@ -56,8 +56,8 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name' => env('MAIL_FROM_NAME', 'Example'),
+        'address' => env('MAIL_FROM_ADDRESS', 'mail@FindAShelterPuppy.com'),
+        'name' => env('MAIL_FROM_NAME', 'FindAShelterPuppy.com'),
     ],
 
     /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,7 +32,7 @@ Route::get('/user/miles/{email}', 'UserController@getUserMiles');
 Route::post('/selection/{zip}/{maxMiles}', 'FormController@storeSelection');
 
 Route::get('/test/notification/{email}', function($email){
-$user = User::where('email', $email)->first();
-$user->notify(new PetArrived($user->email, 95492, 100));
-dd('done');
+    $user = User::where('email', $email)->first();
+    $user->notify(new PetArrived($user->email, 95492, 100));
+    dd('done');
 });


### PR DESCRIPTION
## Whats This PR Do?
- Changes mailer from using smtp to mailgun api
- Minor Formatting  the receiving email layout

## Steps to Review
- Add a User to the Database with an email you have access too (See me for help)
- Hit the Route /test/notification/youremail@notreal.com
- Verify the email you received has a sender of 'mail@findashelterpuppy.com'
