### PR TITLE
FASP-39 Added Google Analytics Passcode 

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>http://findashelterpuppy.com/</loc>
+  <lastmod>2018-09-11T05:41:05+00:00</lastmod>
+</url>
+
+
+</urlset>

--- a/resources/views/partials/master.blade.php
+++ b/resources/views/partials/master.blade.php
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Global site tag (gtag.js) - Google Analytics Tracking code -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-125573782-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-125573782-1');
+    </script>
+    <!-- end google analytics -->
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## What Does This PR Do?
- Added google analytics passcode to the head of our master.blade.php so that google can see that we are the legal owners of this website and we can then have access to our own google analytics / google console account to track the website stats

## Steps to Review
- load the welcome page and results page and make sure it looks as the original