### PR TITLE
FASP-28 Cache results page data

### DIFF
--- a/app/Http/Controllers/BreedController.php
+++ b/app/Http/Controllers/BreedController.php
@@ -8,6 +8,7 @@ use App\Found_Dog;
 use App\Services\ExternalPetApiService;
 use App\Services\UserService;
 use App\Services\ValidationService;
+use Carbon\Carbon;
 
 class BreedController extends Controller
 {
@@ -25,8 +26,9 @@ class BreedController extends Controller
         if($isTokenValid == true) {
             $found_dogs = Found_Dog::BreedIdAndMiles($email);
             $userSelection = $this->userService->getUserSelection($email);
-            if(cache)
-            $results = $this->externalPetApiService->appendFoundDogCollectionDataToApiData($found_dogs);
+            $results = cache()->remember('results',10, function() use ($found_dogs){
+                return $this->externalPetApiService->appendFoundDogCollectionDataToApiData($found_dogs);
+            });
             return view('results')->with('dogData', $results)->with('userSelection', $userSelection);
         } else{
             return redirect('/');

--- a/app/Http/Controllers/BreedController.php
+++ b/app/Http/Controllers/BreedController.php
@@ -25,6 +25,7 @@ class BreedController extends Controller
         if($isTokenValid == true) {
             $found_dogs = Found_Dog::BreedIdAndMiles($email);
             $userSelection = $this->userService->getUserSelection($email);
+            if(cache)
             $results = $this->externalPetApiService->appendFoundDogCollectionDataToApiData($found_dogs);
             return view('results')->with('dogData', $results)->with('userSelection', $userSelection);
         } else{

--- a/app/Http/Controllers/BreedController.php
+++ b/app/Http/Controllers/BreedController.php
@@ -24,9 +24,11 @@ class BreedController extends Controller
     {
         $isTokenValid = $this->userService->checkUserToken($token, $email);
         if($isTokenValid == true) {
+            $endOfDay = Carbon::now()->endOfDay();
             $found_dogs = Found_Dog::BreedIdAndMiles($email);
             $userSelection = $this->userService->getUserSelection($email);
-            $results = cache()->remember('results',10, function() use ($found_dogs){
+            //Check if email exists as a key in cache, if not store data in cache with key being user's email
+            $results = cache()->remember("$email", $endOfDay, function() use ($found_dogs){
                 return $this->externalPetApiService->appendFoundDogCollectionDataToApiData($found_dogs);
             });
             return view('results')->with('dogData', $results)->with('userSelection', $userSelection);

--- a/resources/views/results.blade.php
+++ b/resources/views/results.blade.php
@@ -6,7 +6,7 @@
 		<div class="row">
 			<div class="colxs-12">
 				<div class="navbar navbar-default navbar-static-top">
-					<p class="navbar-text navbar-right padding-nav-txt"><a href="../" class="navbar-link txt-black">Home</a></p>
+					<p class="navbar-text navbar-right padding-nav-txt"><a href="{{url('/')}}" class="navbar-link txt-black">Home</a></p>
 				</div>
 			</div>
 		</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,19 +28,8 @@ Route::get('/user/zip/{email}', 'UserController@getUserZip');
 Route::get('/user/breed/{email}', 'UserController@getUserBreed');
 Route::get('/user/miles/{email}', 'UserController@getUserMiles');
 
-Route::get('/test/notification/{email}', function($email){
+/*Route::get('/test/notification/{email}', function($email){
     $user = User::where('email', $email)->first();
     $user->notify(new PetArrived($user, 95492, 100));
     dd('done');
-});
-
-Route::get('/test/cache', function(){
-    if(cache()->has('users')){
-        return cache()->get('users','Error');
-    } else {
-        dd('false');
-        $users = User::all();
-        cache()->add('users', $users,5);
-        return $users;
-    }
-});
+});*/

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,3 +33,14 @@ Route::get('/test/notification/{email}', function($email){
     $user->notify(new PetArrived($user, 95492, 100));
     dd('done');
 });
+
+Route::get('/test/cache', function(){
+    if(cache()->has('users')){
+        return cache()->get('users','Error');
+    } else {
+        dd('false');
+        $users = User::all();
+        cache()->add('users', $users,5);
+        return $users;
+    }
+});


### PR DESCRIPTION
## Whats This PR Do?
- Adds Caching data used on Results view
- Fixes Results Page home link

## Steps to Review
- Navigate to and click the "Show Me" button on a user's notification email
- Verify the first page loads with normal speed (The first time does not use the cache, so is slower)
- Refresh the Page and verify the page load has significantly improved (Second time used cache, faster)
